### PR TITLE
Added support for new push opt-in an tracking opt-in events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added support for new push opt-in and tracking opt-in events
 * Added new extension config to set an alternative target shop number
+* Added new extension config to activate a debug mode that logs all events to the console
 
 ## 1.2.0 (September 17, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0 (November 6, 2024)
+
+* Added support for new push opt-in and tracking opt-in events
+* Added new extension config to set an alternative target shop number
+
 ## 1.2.0 (September 17, 2019)
 
 * Converted devDependencies to peerDependencies to improve compatibility to PWA 5.x and PWA 6.x

--- a/extension-config.json
+++ b/extension-config.json
@@ -33,6 +33,15 @@
         "type": "text",
         "label": "An alternative target shop number for all tracking requests"
       }
+    },
+    "debugEnabled": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "type": "checkbox",
+        "label": "Enables debug mode"
+      }
     }
   }
 }

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.2",
+  "version": "1.3.0-beta.1",
   "id": "@shopgate/tracking-shopgate-analytics",
   "components": [
     {

--- a/extension-config.json
+++ b/extension-config.json
@@ -21,8 +21,17 @@
       "destination": "frontend",
       "default": null,
       "params": {
-        "type": "json",
+        "type": "text",
         "label": "The target stage for all tracking requests"
+      }
+    },
+    "overrideShopNumber": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": null,
+      "params": {
+        "type": "text",
+        "label": "An alternative target shop number for all tracking requests"
       }
     }
   }

--- a/frontend/src/Plugin.js
+++ b/frontend/src/Plugin.js
@@ -1,6 +1,7 @@
 /* global sgAnalytics */
 import SgTrackingPlugin from '@shopgate/tracking-core/plugins/Base';
 import initSDK from './sdk';
+import { debugEnabled } from '../config';
 
 const SUPPORTED_OPT_IN_EVENTS = [
   'softPushOptInShown',
@@ -63,6 +64,23 @@ class ShopgateAnalytics extends SgTrackingPlugin {
   }
 
   /**
+   * Sends an event to shopgate analytics
+   * @param {string} eventName Event name
+   * @param {Object} eventPayload  Event payload
+   */
+  trackSgAnalyticsEvent = (eventName, eventPayload) => {
+    if (debugEnabled) {
+      console.log('%c SgAnalytics', 'color: #8e44ad', 'Event Sent', {
+        name: eventName,
+        payload: eventPayload,
+        config: this.config,
+      });
+    }
+
+    sgAnalytics('track', eventName, eventPayload);
+  };
+
+  /**
    * Formats product data to the analytics format.
    * @param {Object} product Raw product data.
    * @return {Object}
@@ -111,7 +129,7 @@ class ShopgateAnalytics extends SgTrackingPlugin {
         };
       }
 
-      sgAnalytics('track', 'pageViewed', sdkData);
+      this.trackSgAnalyticsEvent('pageViewed', sdkData);
     });
 
     this.register.addToCart((data, rawData, _, state) => {
@@ -134,7 +152,7 @@ class ShopgateAnalytics extends SgTrackingPlugin {
         };
       }
 
-      sgAnalytics('track', 'productAddedToCart', sdkData);
+      this.trackSgAnalyticsEvent('productAddedToCart', sdkData);
     });
 
     this.register.purchase((data, rawData, _, state) => {
@@ -189,7 +207,7 @@ class ShopgateAnalytics extends SgTrackingPlugin {
         };
       }
 
-      sgAnalytics('track', 'checkoutCompleted', sdkData);
+      this.trackSgAnalyticsEvent('checkoutCompleted', sdkData);
     });
 
     this.register.customEvent((data, rawData, _, state) => {
@@ -216,7 +234,7 @@ class ShopgateAnalytics extends SgTrackingPlugin {
         };
       }
 
-      sgAnalytics('track', eventName, sdkData);
+      this.trackSgAnalyticsEvent(eventName, sdkData);
     });
   }
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -16,7 +16,7 @@ export default function init(options) {
   const plugin = new Plugin({
     ...options,
     stage,
-    shopNumber,
+    shopNumber: config.overrideShopNumber || shopNumber,
     access: 'App',
   });
 


### PR DESCRIPTION
This pull requests adds support for the new push opt-in and tracking opt-in events.
Events are implemented via the universal `customEvent` tracking event, so the plugin operates with a positive list that allows just to track known event types.